### PR TITLE
client: relax reply checks, remove IsReply and IsReplyFor

### DIFF
--- a/client_request_test.go
+++ b/client_request_test.go
@@ -198,39 +198,6 @@ func TestClientRequestARPRequestInsteadOfResponse(t *testing.T) {
 	}
 }
 
-func TestClientRequestARPResponseWrongTargetIP(t *testing.T) {
-	c := &Client{
-		ifi: &net.Interface{
-			HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 0},
-		},
-		ip: net.IPv4(192, 168, 1, 1).To4(),
-		p: &bufferReadFromPacketConn{
-			b: bytes.NewBuffer(append([]byte{
-				// Ethernet frame
-				0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0,
-				0x08, 0x06,
-				// ARP Packet not bound for this IP address
-				0, 1,
-				0x08, 0x06,
-				6,
-				4,
-				0, 2,
-				0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0,
-				192, 168, 1, 2, // Wrong IP address
-			}, make([]byte, 46)...)),
-		},
-	}
-
-	_, got := c.Resolve(net.IPv4zero)
-	if want := io.EOF; want != got {
-		t.Fatalf("unexpected error while reading ARP response with wrong target IP:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-}
-
 func TestClientRequestARPResponseWrongSenderIP(t *testing.T) {
 	c := &Client{
 		ifi: &net.Interface{
@@ -264,39 +231,6 @@ func TestClientRequestARPResponseWrongSenderIP(t *testing.T) {
 	}
 }
 
-func TestClientRequestARPResponseWrongTargetHardwareAddr(t *testing.T) {
-	c := &Client{
-		ifi: &net.Interface{
-			HardwareAddr: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
-		},
-		ip: net.IPv4(192, 168, 1, 1).To4(),
-		p: &bufferReadFromPacketConn{
-			b: bytes.NewBuffer(append([]byte{
-				// Ethernet frame
-				0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
-				0, 0, 0, 0, 0, 0,
-				0x08, 0x06,
-				// ARP Packet not bound for this hardware address
-				0, 1,
-				0x08, 0x06,
-				6,
-				4,
-				0, 2,
-				0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0,
-				0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // Wrong hardware address
-				192, 168, 1, 1,
-			}, make([]byte, 46)...)),
-		},
-	}
-
-	_, got := c.Resolve(net.IPv4zero)
-	if want := io.EOF; want != got {
-		t.Fatalf("unexpected error while reading ARP response with wrong target hardware address:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-}
-
 func TestClientRequestOK(t *testing.T) {
 	c := &Client{
 		ifi: &net.Interface{
@@ -317,8 +251,8 @@ func TestClientRequestOK(t *testing.T) {
 				0, 2,
 				0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
 				192, 168, 1, 10,
-				0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
-				192, 168, 1, 1,
+				0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, // mac needn't match ours
+				192, 168, 1, 2, // ip needn't match ours
 			}, make([]byte, 40)...)),
 		},
 	}


### PR DESCRIPTION
RFC 826 doesn't say that we should check the target hardware address or
target protocol address when processing replies. Instead, replies should
be considered unconditionally.

RFC 5227 (page 16) goes a step further, and explicitly calls out broken
implementations that make such checks.

Furthermore, ARP replies can be broadcasts.

This removes IsReply and IsReplyFor, as they'd become trivial.