### PR TITLE
client: Add helper to fetch client hardware address

### DIFF
--- a/client.go
+++ b/client.go
@@ -201,6 +201,12 @@ func (c *Client) SetWriteDeadline(t time.Time) error {
 	return c.p.SetWriteDeadline(t)
 }
 
+// HardwareAddr fetches the hardware address for the interface associated
+// with the connection.
+func (c Client) HardwareAddr() net.HardwareAddr {
+	return c.ifi.HardwareAddr
+}
+
 // firstIPv4Addr attempts to retrieve the first detected IPv4 address from an
 // input slice of network addresses.
 func firstIPv4Addr(addrs []net.Addr) (net.IP, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -72,6 +72,18 @@ func TestClientSetWriteDeadline(t *testing.T) {
 	}
 }
 
+func TestClientHardwareAddr(t *testing.T) {
+	c := &Client{
+		ifi: &net.Interface{
+			HardwareAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5},
+		},
+	}
+
+	if want, got := c.ifi.HardwareAddr.String(), c.HardwareAddr().String(); want != got {
+		t.Fatalf("unexpected hardware address: %v != %v", want, got)
+	}
+}
+
 func Test_newClient(t *testing.T) {
 	var tests = []struct {
 		desc  string
@@ -276,3 +288,4 @@ func (noopPacketConn) LocalAddr() net.Addr                { return nil }
 func (noopPacketConn) SetDeadline(t time.Time) error      { return nil }
 func (noopPacketConn) SetReadDeadline(t time.Time) error  { return nil }
 func (noopPacketConn) SetWriteDeadline(t time.Time) error { return nil }
+func (noopPacketConn) HardwareAddr() net.HardwareAddr     { return nil }


### PR DESCRIPTION
This makes a Reply() with the underlying device mac address possible without more context then the client.