### PR TITLE
client: Defer errNoIPv4Addr until request is made

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,6 +73,10 @@ func (c *Client) Close() error {
 // hardware address, Request allows sending many requests in a row,
 // retrieving the responses afterwards.
 func (c *Client) Request(ip net.IP) error {
+	if c.ip == nil {
+		return errNoIPv4Addr
+	}
+
 	// Create ARP packet for broadcast address to attempt to find the
 	// hardware address of the input IP address
 	arp, err := NewPacket(OperationRequest, c.ifi.HardwareAddr, c.ip, ethernet.Broadcast, ip)
@@ -221,5 +225,5 @@ func firstIPv4Addr(addrs []net.Addr) (net.IP, error) {
 		}
 	}
 
-	return nil, errNoIPv4Addr
+	return nil, nil
 }

--- a/client_request_test.go
+++ b/client_request_test.go
@@ -8,9 +8,20 @@ import (
 	"testing"
 )
 
+func TestClientRequestNoIPv4Address(t *testing.T) {
+	c := &Client{}
+
+	_, got := c.Resolve(net.IPv4zero)
+	if want := errNoIPv4Addr; want != got {
+		t.Fatalf("unexpected error for no IPv4 address:\n- want: %v\n-  got: %v",
+			want, got)
+	}
+}
+
 func TestClientRequestInvalidSourceHardwareAddr(t *testing.T) {
 	c := &Client{
 		ifi: &net.Interface{},
+		ip:  net.IPv4zero,
 	}
 
 	_, got := c.Resolve(net.IPv4zero)
@@ -25,6 +36,7 @@ func TestClientRequestIPv6Address(t *testing.T) {
 		ifi: &net.Interface{
 			HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 0},
 		},
+		ip: net.IPv4zero,
 	}
 
 	_, got := c.Resolve(net.IPv6loopback)

--- a/client_test.go
+++ b/client_test.go
@@ -81,7 +81,7 @@ func Test_newClient(t *testing.T) {
 	}{
 		{
 			desc: "no network addresses",
-			err:  errNoIPv4Addr,
+			c:    &Client{},
 		},
 		{
 			desc: "OK",
@@ -94,7 +94,6 @@ func Test_newClient(t *testing.T) {
 			c: &Client{
 				ip: net.IPv4(192, 168, 1, 1).To4(),
 			},
-			err: errNoIPv4Addr,
 		},
 	}
 
@@ -125,7 +124,6 @@ func Test_firstIPv4Addr(t *testing.T) {
 	}{
 		{
 			desc: "no network addresses",
-			err:  errNoIPv4Addr,
 		},
 		{
 			desc: "non-IP network",
@@ -135,7 +133,6 @@ func Test_firstIPv4Addr(t *testing.T) {
 					Net:  "unix",
 				},
 			},
-			err: errNoIPv4Addr,
 		},
 		{
 			desc: "bad CIDR address",
@@ -162,7 +159,6 @@ func Test_firstIPv4Addr(t *testing.T) {
 					},
 				},
 			},
-			err: errNoIPv4Addr,
 		},
 		{
 			desc: "IPv4 address only",


### PR DESCRIPTION
This enables proxyarpd workflows where the interface has no IPv4 address.