### PR TITLE
Allow the user to create a Client from a PacketConn

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,7 +33,15 @@ func NewClient(ifi *net.Interface) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewClientPacketConn(ifi, p)
+}
 
+// NewClientPacketConn creates a new Client using the specified network interface
+// and net.PacketConn. This allows the caller to define exactly how they bind to the
+// net.PacketConn. This is most useful to define what protocol to pass to socket(7).
+//
+// In most cases, callers would be better off calling NewClient.
+func NewClientPacketConn(ifi *net.Interface, p net.PacketConn) (*Client, error) {
 	// Check for usable IPv4 addresses for the Client
 	addrs, err := ifi.Addrs()
 	if err != nil {


### PR DESCRIPTION
In particular, on Linux, this will allow the user to create an
arp.Client in promiscious mode, by having raw.ListenPacket call socket(2)
with htons(ETH_P_ALL) by passing `syscall.ETH_P_ALL` into it.

An example replacement of an existing call site would look something
like:

```
dev, err := net.InterfaceByName("name0")
if err != nil {
    return err
}
packetConn, err := raw.ListenPacket(dev, syscall.ETH_P_ALL)
if err != nil {
    return err
}
arpClient, err := arp.NewClientPacketConn(dev, packetConn)
...
```