### PR TITLE
migrate from net.IP to netip.Addr

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,8 +93,7 @@ func (c *Client) Close() error {
 // hardware address, Request allows sending many requests in a row,
 // retrieving the responses afterwards.
 func (c *Client) Request(ip netip.Addr) error {
-	var invalidIP netip.Addr
-	if c.ip == invalidIP {
+	if !c.ip.IsValid() {
 		return errNoIPv4Addr
 	}
 
@@ -240,5 +239,5 @@ func firstIPv4Addr(addrs []netip.Addr) (netip.Addr, error) {
 			return a, nil
 		}
 	}
-	return netip.Addr{}, nil
+	return netip.Addr{}, errNoIPv4Addr
 }

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package arp
 import (
 	"errors"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/mdlayher/ethernet"
@@ -21,7 +22,7 @@ const protocolARP = 0x0806
 // ARP packets.
 type Client struct {
 	ifi *net.Interface
-	ip  net.IP
+	ip  netip.Addr
 	p   net.PacketConn
 }
 
@@ -50,13 +51,22 @@ func New(ifi *net.Interface, p net.PacketConn) (*Client, error) {
 		return nil, err
 	}
 
-	return newClient(ifi, p, addrs)
+	ipaddrs := make([]netip.Addr, len(addrs))
+	for i, a := range addrs {
+		ipPrefix, err := netip.ParsePrefix(a.String())
+		if err != nil {
+			return nil, err
+		}
+		ipaddrs[i] = ipPrefix.Addr()
+	}
+
+	return newClient(ifi, p, ipaddrs)
 }
 
 // newClient is the internal, generic implementation of newClient.  It is used
 // to allow an arbitrary net.PacketConn to be used in a Client, so testing
 // is easier to accomplish.
-func newClient(ifi *net.Interface, p net.PacketConn, addrs []net.Addr) (*Client, error) {
+func newClient(ifi *net.Interface, p net.PacketConn, addrs []netip.Addr) (*Client, error) {
 	ip, err := firstIPv4Addr(addrs)
 	if err != nil {
 		return nil, err
@@ -82,8 +92,9 @@ func (c *Client) Close() error {
 // Unlike Resolve, which provides an easier interface for getting the
 // hardware address, Request allows sending many requests in a row,
 // retrieving the responses afterwards.
-func (c *Client) Request(ip net.IP) error {
-	if c.ip == nil {
+func (c *Client) Request(ip netip.Addr) error {
+	var invalidIP netip.Addr
+	if c.ip == invalidIP {
 		return errNoIPv4Addr
 	}
 
@@ -101,7 +112,7 @@ func (c *Client) Request(ip net.IP) error {
 // be used concurrently with Read. If you're using Read (usually in a
 // loop), you need to use Request instead. Resolve may read more than
 // one message if it receives messages unrelated to the request.
-func (c *Client) Resolve(ip net.IP) (net.HardwareAddr, error) {
+func (c *Client) Resolve(ip netip.Addr) (net.HardwareAddr, error) {
 	err := c.Request(ip)
 	if err != nil {
 		return nil, err
@@ -114,7 +125,7 @@ func (c *Client) Resolve(ip net.IP) (net.HardwareAddr, error) {
 			return nil, err
 		}
 
-		if arp.Operation != OperationReply || !arp.SenderIP.Equal(ip) {
+		if arp.Operation != OperationReply || arp.SenderIP != ip {
 			continue
 		}
 
@@ -175,7 +186,7 @@ func (c *Client) WriteTo(p *Packet, addr net.HardwareAddr) error {
 //
 // For more fine-grained control, use WriteTo to write a custom
 // response.
-func (c *Client) Reply(req *Packet, hwAddr net.HardwareAddr, ip net.IP) error {
+func (c *Client) Reply(req *Packet, hwAddr net.HardwareAddr, ip netip.Addr) error {
 	p, err := NewPacket(OperationReply, hwAddr, ip, req.SenderHardwareAddr, req.SenderIP)
 	if err != nil {
 		return err
@@ -223,23 +234,11 @@ func (c Client) HardwareAddr() net.HardwareAddr {
 
 // firstIPv4Addr attempts to retrieve the first detected IPv4 address from an
 // input slice of network addresses.
-func firstIPv4Addr(addrs []net.Addr) (net.IP, error) {
+func firstIPv4Addr(addrs []netip.Addr) (netip.Addr, error) {
 	for _, a := range addrs {
-		if a.Network() != "ip+net" {
-			continue
-		}
-
-		ip, _, err := net.ParseCIDR(a.String())
-		if err != nil {
-			return nil, err
-		}
-
-		// "If ip is not an IPv4 address, To4 returns nil."
-		// Reference: http://golang.org/pkg/net/#IP.To4
-		if ip4 := ip.To4(); ip4 != nil {
-			return ip4, nil
+		if a.Is4() {
+			return a, nil
 		}
 	}
-
-	return nil, nil
+	return netip.Addr{}, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -94,6 +94,7 @@ func Test_newClient(t *testing.T) {
 		{
 			desc: "no network addresses",
 			c:    &Client{},
+			err:  errNoIPv4Addr,
 		},
 		{
 			desc: "OK",
@@ -124,116 +125,6 @@ func Test_newClient(t *testing.T) {
 	}
 }
 
-// func Test_firstIPv4Addr(t *testing.T) {
-// 	tests := []struct {
-// 		desc  string
-// 		addrs []net.Addr
-// 		ip    net.IP
-// 		err   error
-// 	}{
-// 		{
-// 			desc: "no network addresses",
-// 		},
-// 		{
-// 			desc: "non-IP network",
-// 			addrs: []net.Addr{
-// 				&net.UnixAddr{
-// 					Name: "foo.sock",
-// 					Net:  "unix",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			desc: "bad CIDR address",
-// 			addrs: []net.Addr{
-// 				&net.IPNet{
-// 					IP: net.IPv4(192, 168, 1, 1),
-// 				},
-// 			},
-// 			err: &net.ParseError{
-// 				Type: "CIDR address",
-// 				Text: "<nil>",
-// 			},
-// 		},
-// 		{
-// 			desc: "IPv6 address only",
-// 			addrs: []net.Addr{
-// 				&net.IPNet{
-// 					IP: net.IPv6loopback,
-// 					Mask: []byte{
-// 						0xff, 0xff, 0xff, 0xff,
-// 						0xff, 0xff, 0xff, 0xff,
-// 						0, 0, 0, 0,
-// 						0, 0, 0, 0,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		{
-// 			desc: "IPv4 address only",
-// 			addrs: []net.Addr{
-// 				&net.IPNet{
-// 					IP:   net.IPv4(192, 168, 1, 1),
-// 					Mask: []byte{255, 255, 255, 0},
-// 				},
-// 			},
-// 			ip: net.IPv4(192, 168, 1, 1),
-// 		},
-// 		{
-// 			desc: "IPv4 and IPv6 addresses",
-// 			addrs: []net.Addr{
-// 				&net.IPNet{
-// 					IP: net.IPv6loopback,
-// 					Mask: []byte{
-// 						0xff, 0xff, 0xff, 0xff,
-// 						0xff, 0xff, 0xff, 0xff,
-// 						0, 0, 0, 0,
-// 						0, 0, 0, 0,
-// 					},
-// 				},
-// 				&net.IPNet{
-// 					IP:   net.IPv4(192, 168, 1, 1),
-// 					Mask: []byte{255, 255, 255, 0},
-// 				},
-// 			},
-// 			ip: net.IPv4(192, 168, 1, 1),
-// 		},
-// 		{
-// 			desc: "multiple IPv4 addresses",
-// 			addrs: []net.Addr{
-// 				&net.IPNet{
-// 					IP:   net.IPv4(10, 0, 0, 1),
-// 					Mask: []byte{255, 0, 0, 0},
-// 				},
-// 				&net.IPNet{
-// 					IP:   net.IPv4(192, 168, 1, 1),
-// 					Mask: []byte{255, 255, 255, 0},
-// 				},
-// 			},
-// 			ip: net.IPv4(10, 0, 0, 1),
-// 		},
-// 	}
-//
-// 	for i, tt := range tests {
-// 		ip, err := firstIPv4Addr(tt.addrs)
-// 		if err != nil {
-// 			if want, got := tt.err.Error(), err.Error(); want != got {
-// 				t.Fatalf("[%02d] test %q, unexpected error: %v != %v",
-// 					i, tt.desc, want, got)
-// 			}
-//
-// 			continue
-// 		}
-//
-// 		if want, got := tt.ip.To4(), ip.To4(); !want.Equal(got) {
-// 			t.Fatalf("[%02d] test %q, unexpected IPv4 address: %v != %v",
-// 				i, tt.desc, want, got)
-// 		}
-// 	}
-// }
-//
-// closeCapturePacketConn is a net.PacketConn which captures when
-// it is closed.
 type closeCapturePacketConn struct {
 	closed bool
 

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package arp
 
 import (
 	"net"
+	"net/netip"
 	"reflect"
 	"testing"
 	"time"
@@ -86,7 +87,7 @@ func TestClientHardwareAddr(t *testing.T) {
 func Test_newClient(t *testing.T) {
 	tests := []struct {
 		desc  string
-		addrs []net.Addr
+		addrs []netip.Addr
 		c     *Client
 		err   error
 	}{
@@ -96,14 +97,11 @@ func Test_newClient(t *testing.T) {
 		},
 		{
 			desc: "OK",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP:   net.IPv4(192, 168, 1, 1),
-					Mask: []byte{255, 255, 255, 0},
-				},
+			addrs: []netip.Addr{
+				netip.MustParseAddr("192.168.1.1"),
 			},
 			c: &Client{
-				ip: net.IPv4(192, 168, 1, 1).To4(),
+				ip: netip.MustParseAddr("192.168.1.1"),
 			},
 		},
 	}
@@ -126,114 +124,114 @@ func Test_newClient(t *testing.T) {
 	}
 }
 
-func Test_firstIPv4Addr(t *testing.T) {
-	tests := []struct {
-		desc  string
-		addrs []net.Addr
-		ip    net.IP
-		err   error
-	}{
-		{
-			desc: "no network addresses",
-		},
-		{
-			desc: "non-IP network",
-			addrs: []net.Addr{
-				&net.UnixAddr{
-					Name: "foo.sock",
-					Net:  "unix",
-				},
-			},
-		},
-		{
-			desc: "bad CIDR address",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP: net.IPv4(192, 168, 1, 1),
-				},
-			},
-			err: &net.ParseError{
-				Type: "CIDR address",
-				Text: "<nil>",
-			},
-		},
-		{
-			desc: "IPv6 address only",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP: net.IPv6loopback,
-					Mask: []byte{
-						0xff, 0xff, 0xff, 0xff,
-						0xff, 0xff, 0xff, 0xff,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-					},
-				},
-			},
-		},
-		{
-			desc: "IPv4 address only",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP:   net.IPv4(192, 168, 1, 1),
-					Mask: []byte{255, 255, 255, 0},
-				},
-			},
-			ip: net.IPv4(192, 168, 1, 1),
-		},
-		{
-			desc: "IPv4 and IPv6 addresses",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP: net.IPv6loopback,
-					Mask: []byte{
-						0xff, 0xff, 0xff, 0xff,
-						0xff, 0xff, 0xff, 0xff,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-					},
-				},
-				&net.IPNet{
-					IP:   net.IPv4(192, 168, 1, 1),
-					Mask: []byte{255, 255, 255, 0},
-				},
-			},
-			ip: net.IPv4(192, 168, 1, 1),
-		},
-		{
-			desc: "multiple IPv4 addresses",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP:   net.IPv4(10, 0, 0, 1),
-					Mask: []byte{255, 0, 0, 0},
-				},
-				&net.IPNet{
-					IP:   net.IPv4(192, 168, 1, 1),
-					Mask: []byte{255, 255, 255, 0},
-				},
-			},
-			ip: net.IPv4(10, 0, 0, 1),
-		},
-	}
-
-	for i, tt := range tests {
-		ip, err := firstIPv4Addr(tt.addrs)
-		if err != nil {
-			if want, got := tt.err.Error(), err.Error(); want != got {
-				t.Fatalf("[%02d] test %q, unexpected error: %v != %v",
-					i, tt.desc, want, got)
-			}
-
-			continue
-		}
-
-		if want, got := tt.ip.To4(), ip.To4(); !want.Equal(got) {
-			t.Fatalf("[%02d] test %q, unexpected IPv4 address: %v != %v",
-				i, tt.desc, want, got)
-		}
-	}
-}
-
+// func Test_firstIPv4Addr(t *testing.T) {
+// 	tests := []struct {
+// 		desc  string
+// 		addrs []net.Addr
+// 		ip    net.IP
+// 		err   error
+// 	}{
+// 		{
+// 			desc: "no network addresses",
+// 		},
+// 		{
+// 			desc: "non-IP network",
+// 			addrs: []net.Addr{
+// 				&net.UnixAddr{
+// 					Name: "foo.sock",
+// 					Net:  "unix",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			desc: "bad CIDR address",
+// 			addrs: []net.Addr{
+// 				&net.IPNet{
+// 					IP: net.IPv4(192, 168, 1, 1),
+// 				},
+// 			},
+// 			err: &net.ParseError{
+// 				Type: "CIDR address",
+// 				Text: "<nil>",
+// 			},
+// 		},
+// 		{
+// 			desc: "IPv6 address only",
+// 			addrs: []net.Addr{
+// 				&net.IPNet{
+// 					IP: net.IPv6loopback,
+// 					Mask: []byte{
+// 						0xff, 0xff, 0xff, 0xff,
+// 						0xff, 0xff, 0xff, 0xff,
+// 						0, 0, 0, 0,
+// 						0, 0, 0, 0,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			desc: "IPv4 address only",
+// 			addrs: []net.Addr{
+// 				&net.IPNet{
+// 					IP:   net.IPv4(192, 168, 1, 1),
+// 					Mask: []byte{255, 255, 255, 0},
+// 				},
+// 			},
+// 			ip: net.IPv4(192, 168, 1, 1),
+// 		},
+// 		{
+// 			desc: "IPv4 and IPv6 addresses",
+// 			addrs: []net.Addr{
+// 				&net.IPNet{
+// 					IP: net.IPv6loopback,
+// 					Mask: []byte{
+// 						0xff, 0xff, 0xff, 0xff,
+// 						0xff, 0xff, 0xff, 0xff,
+// 						0, 0, 0, 0,
+// 						0, 0, 0, 0,
+// 					},
+// 				},
+// 				&net.IPNet{
+// 					IP:   net.IPv4(192, 168, 1, 1),
+// 					Mask: []byte{255, 255, 255, 0},
+// 				},
+// 			},
+// 			ip: net.IPv4(192, 168, 1, 1),
+// 		},
+// 		{
+// 			desc: "multiple IPv4 addresses",
+// 			addrs: []net.Addr{
+// 				&net.IPNet{
+// 					IP:   net.IPv4(10, 0, 0, 1),
+// 					Mask: []byte{255, 0, 0, 0},
+// 				},
+// 				&net.IPNet{
+// 					IP:   net.IPv4(192, 168, 1, 1),
+// 					Mask: []byte{255, 255, 255, 0},
+// 				},
+// 			},
+// 			ip: net.IPv4(10, 0, 0, 1),
+// 		},
+// 	}
+//
+// 	for i, tt := range tests {
+// 		ip, err := firstIPv4Addr(tt.addrs)
+// 		if err != nil {
+// 			if want, got := tt.err.Error(), err.Error(); want != got {
+// 				t.Fatalf("[%02d] test %q, unexpected error: %v != %v",
+// 					i, tt.desc, want, got)
+// 			}
+//
+// 			continue
+// 		}
+//
+// 		if want, got := tt.ip.To4(), ip.To4(); !want.Equal(got) {
+// 			t.Fatalf("[%02d] test %q, unexpected IPv4 address: %v != %v",
+// 				i, tt.desc, want, got)
+// 		}
+// 	}
+// }
+//
 // closeCapturePacketConn is a net.PacketConn which captures when
 // it is closed.
 type closeCapturePacketConn struct {

--- a/cmd/arpc/main.go
+++ b/cmd/arpc/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/mdlayher/arp"
@@ -45,7 +46,10 @@ func main() {
 	}
 
 	// Request hardware address for IP address
-	ip := net.ParseIP(*ipFlag).To4()
+	ip, err := netip.ParseAddr(*ipFlag)
+	if err != nil {
+		log.Fatal(err)
+	}
 	mac, err := c.Resolve(ip)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/proxyarpd/main.go
+++ b/cmd/proxyarpd/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/netip"
 
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ethernet"
@@ -27,8 +28,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ip := net.ParseIP(*ipFlag).To4()
-	if ip == nil {
+	ip, err := netip.ParseAddr(*ipFlag)
+	if err != nil || !ip.Is4() {
 		log.Fatalf("invalid IPv4 address: %q", *ipFlag)
 	}
 
@@ -63,7 +64,7 @@ func main() {
 		log.Printf("request: who-has %s?  tell %s (%s)", pkt.TargetIP, pkt.SenderIP, pkt.SenderHardwareAddr)
 
 		// Ignore ARP requests which do not indicate the target IP
-		if !pkt.TargetIP.Equal(ip) {
+		if pkt.TargetIP != ip {
 			continue
 		}
 

--- a/packet.go
+++ b/packet.go
@@ -96,7 +96,7 @@ func NewPacket(op Operation, srcHW net.HardwareAddr, srcIP netip.Addr, dstHW net
 	// Validate IP addresses to ensure they are IPv4 addresses, and
 	// correct length
 	var invalidIP netip.Addr
-	if !srcIP.Is4() || srcIP == invalidIP {
+	if !srcIP.IsValid() || !srcIP.Is4() {
 		return nil, ErrInvalidIP
 	}
 	if !dstIP.Is4() || dstIP == invalidIP {

--- a/packet.go
+++ b/packet.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/netip"
 
 	"github.com/mdlayher/ethernet"
 )
@@ -62,14 +63,14 @@ type Packet struct {
 	SenderHardwareAddr net.HardwareAddr
 
 	// SenderIP specifies the IPv4 address of the sender of this Packet.
-	SenderIP net.IP
+	SenderIP netip.Addr
 
 	// TargetHardwareAddr specifies the hardware address of the target of this
 	// Packet.
 	TargetHardwareAddr net.HardwareAddr
 
 	// TargetIP specifies the IPv4 address of the target of this Packet.
-	TargetIP net.IP
+	TargetIP netip.Addr
 }
 
 // NewPacket creates a new Packet from an input Operation and hardware/IPv4
@@ -80,7 +81,7 @@ type Packet struct {
 //
 // If either IP address is not an IPv4 address, or there is a length mismatch
 // between the two, ErrInvalidIP is returned.
-func NewPacket(op Operation, srcHW net.HardwareAddr, srcIP net.IP, dstHW net.HardwareAddr, dstIP net.IP) (*Packet, error) {
+func NewPacket(op Operation, srcHW net.HardwareAddr, srcIP netip.Addr, dstHW net.HardwareAddr, dstIP netip.Addr) (*Packet, error) {
 	// Validate hardware addresses for minimum length, and matching length
 	if len(srcHW) < 6 {
 		return nil, ErrInvalidHardwareAddr
@@ -94,12 +95,11 @@ func NewPacket(op Operation, srcHW net.HardwareAddr, srcIP net.IP, dstHW net.Har
 
 	// Validate IP addresses to ensure they are IPv4 addresses, and
 	// correct length
-	srcIP = srcIP.To4()
-	if srcIP == nil {
+	var invalidIP netip.Addr
+	if !srcIP.Is4() || srcIP == invalidIP {
 		return nil, ErrInvalidIP
 	}
-	dstIP = dstIP.To4()
-	if dstIP == nil {
+	if !dstIP.Is4() || dstIP == invalidIP {
 		return nil, ErrInvalidIP
 	}
 
@@ -113,7 +113,7 @@ func NewPacket(op Operation, srcHW net.HardwareAddr, srcIP net.IP, dstHW net.Har
 
 		// Populate other fields using input data
 		HardwareAddrLength: uint8(len(srcHW)),
-		IPLength:           uint8(len(srcIP)),
+		IPLength:           uint8(4),
 		Operation:          op,
 		SenderHardwareAddr: srcHW,
 		SenderIP:           srcIP,
@@ -161,13 +161,15 @@ func (p *Packet) MarshalBinary() ([]byte, error) {
 	copy(b[n:n+hal], p.SenderHardwareAddr)
 	n += hal
 
-	copy(b[n:n+pl], p.SenderIP)
+	sender4 := p.SenderIP.As4()
+	copy(b[n:n+pl], sender4[:])
 	n += pl
 
 	copy(b[n:n+hal], p.TargetHardwareAddr)
 	n += hal
 
-	copy(b[n:n+pl], p.TargetIP)
+	target4 := p.TargetIP.As4()
+	copy(b[n:n+pl], target4[:])
 
 	return b, nil
 }
@@ -217,7 +219,11 @@ func (p *Packet) UnmarshalBinary(b []byte) error {
 
 	// Sender IP address
 	copy(bb[ml:ml+il], b[n:n+il])
-	p.SenderIP = bb[ml : ml+il]
+	senderIP, ok := netip.AddrFromSlice(bb[ml : ml+il])
+	if !ok {
+		return errors.New("Invalid Sender IP address")
+	}
+	p.SenderIP = senderIP
 	n += il
 
 	// Target hardware address
@@ -227,7 +233,11 @@ func (p *Packet) UnmarshalBinary(b []byte) error {
 
 	// Target IP address
 	copy(bb[ml2+il:ml2+il2], b[n:n+il])
-	p.TargetIP = bb[ml2+il : ml2+il2]
+	targetIP, ok := netip.AddrFromSlice(bb[ml2+il : ml2+il2])
+	if !ok {
+		return errors.New("Invalid Target IP address")
+	}
+	p.TargetIP = targetIP
 
 	return nil
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -43,20 +43,6 @@ func TestNewPacket(t *testing.T) {
 			dstHW: net.HardwareAddr{0, 0, 0, 0, 0, 0, 0, 0},
 			err:   ErrInvalidHardwareAddr,
 		},
-		// {
-		// 	desc:  "short source IPv4 address",
-		// 	srcHW: zeroHW,
-		// 	dstHW: zeroHW,
-		// 	srcIP: net.IP{0, 0, 0},
-		// 	err:   ErrInvalidIP,
-		// },
-		// {
-		// 	desc:  "long source IPv4 address",
-		// 	srcHW: zeroHW,
-		// 	dstHW: zeroHW,
-		// 	srcIP: net.IP{0, 0, 0, 0, 0},
-		// 	err:   ErrInvalidIP,
-		// },
 		{
 			desc:  "IPv6 source IP address",
 			srcHW: zeroHW,
@@ -64,22 +50,6 @@ func TestNewPacket(t *testing.T) {
 			srcIP: netip.IPv6Unspecified(),
 			err:   ErrInvalidIP,
 		},
-		// {
-		// 	desc:  "short destination IPv4 address",
-		// 	srcHW: zeroHW,
-		// 	dstHW: zeroHW,
-		// 	srcIP: net.IPv4zero,
-		// 	dstIP: net.IP{0, 0, 0},
-		// 	err:   ErrInvalidIP,
-		// },
-		// {
-		// 	desc:  "long destination IPv4 address",
-		// 	srcHW: zeroHW,
-		// 	dstHW: zeroHW,
-		// 	srcIP: net.IPv4zero,
-		// 	dstIP: net.IP{0, 0, 0, 0, 0},
-		// 	err:   ErrInvalidIP,
-		// },
 		{
 			desc:  "IPv6 destination IP address",
 			srcHW: zeroHW,

--- a/packet_test.go
+++ b/packet_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"net/netip"
 	"reflect"
 	"testing"
 
@@ -19,9 +20,9 @@ func TestNewPacket(t *testing.T) {
 		desc  string
 		op    Operation
 		srcHW net.HardwareAddr
-		srcIP net.IP
+		srcIP netip.Addr
 		dstHW net.HardwareAddr
-		dstIP net.IP
+		dstIP netip.Addr
 		p     *Packet
 		err   error
 	}{
@@ -42,49 +43,49 @@ func TestNewPacket(t *testing.T) {
 			dstHW: net.HardwareAddr{0, 0, 0, 0, 0, 0, 0, 0},
 			err:   ErrInvalidHardwareAddr,
 		},
-		{
-			desc:  "short source IPv4 address",
-			srcHW: zeroHW,
-			dstHW: zeroHW,
-			srcIP: net.IP{0, 0, 0},
-			err:   ErrInvalidIP,
-		},
-		{
-			desc:  "long source IPv4 address",
-			srcHW: zeroHW,
-			dstHW: zeroHW,
-			srcIP: net.IP{0, 0, 0, 0, 0},
-			err:   ErrInvalidIP,
-		},
+		// {
+		// 	desc:  "short source IPv4 address",
+		// 	srcHW: zeroHW,
+		// 	dstHW: zeroHW,
+		// 	srcIP: net.IP{0, 0, 0},
+		// 	err:   ErrInvalidIP,
+		// },
+		// {
+		// 	desc:  "long source IPv4 address",
+		// 	srcHW: zeroHW,
+		// 	dstHW: zeroHW,
+		// 	srcIP: net.IP{0, 0, 0, 0, 0},
+		// 	err:   ErrInvalidIP,
+		// },
 		{
 			desc:  "IPv6 source IP address",
 			srcHW: zeroHW,
 			dstHW: zeroHW,
-			srcIP: net.IPv6zero,
+			srcIP: netip.IPv6Unspecified(),
 			err:   ErrInvalidIP,
 		},
-		{
-			desc:  "short destination IPv4 address",
-			srcHW: zeroHW,
-			dstHW: zeroHW,
-			srcIP: net.IPv4zero,
-			dstIP: net.IP{0, 0, 0},
-			err:   ErrInvalidIP,
-		},
-		{
-			desc:  "long destination IPv4 address",
-			srcHW: zeroHW,
-			dstHW: zeroHW,
-			srcIP: net.IPv4zero,
-			dstIP: net.IP{0, 0, 0, 0, 0},
-			err:   ErrInvalidIP,
-		},
+		// {
+		// 	desc:  "short destination IPv4 address",
+		// 	srcHW: zeroHW,
+		// 	dstHW: zeroHW,
+		// 	srcIP: net.IPv4zero,
+		// 	dstIP: net.IP{0, 0, 0},
+		// 	err:   ErrInvalidIP,
+		// },
+		// {
+		// 	desc:  "long destination IPv4 address",
+		// 	srcHW: zeroHW,
+		// 	dstHW: zeroHW,
+		// 	srcIP: net.IPv4zero,
+		// 	dstIP: net.IP{0, 0, 0, 0, 0},
+		// 	err:   ErrInvalidIP,
+		// },
 		{
 			desc:  "IPv6 destination IP address",
 			srcHW: zeroHW,
 			dstHW: zeroHW,
-			srcIP: net.IPv4zero,
-			dstIP: net.IPv6zero,
+			srcIP: netip.IPv4Unspecified(),
+			dstIP: netip.IPv6Unspecified(),
 			err:   ErrInvalidIP,
 		},
 		{
@@ -92,8 +93,8 @@ func TestNewPacket(t *testing.T) {
 			op:    OperationRequest,
 			srcHW: iboip1,
 			dstHW: ethernet.Broadcast,
-			srcIP: net.IPv4zero,
-			dstIP: net.IPv4zero,
+			srcIP: netip.IPv4Unspecified(),
+			dstIP: netip.IPv4Unspecified(),
 			p: &Packet{
 				HardwareType:       1,
 				ProtocolType:       uint16(ethernet.EtherTypeIPv4),
@@ -101,9 +102,9 @@ func TestNewPacket(t *testing.T) {
 				IPLength:           4,
 				Operation:          OperationRequest,
 				SenderHardwareAddr: iboip1,
-				SenderIP:           net.IPv4zero.To4(),
+				SenderIP:           netip.IPv4Unspecified(),
 				TargetHardwareAddr: ethernet.Broadcast,
-				TargetIP:           net.IPv4zero.To4(),
+				TargetIP:           netip.IPv4Unspecified(),
 			},
 		},
 		{
@@ -111,8 +112,8 @@ func TestNewPacket(t *testing.T) {
 			op:    OperationRequest,
 			srcHW: zeroHW,
 			dstHW: zeroHW,
-			srcIP: net.IPv4zero,
-			dstIP: net.IPv4zero,
+			srcIP: netip.IPv4Unspecified(),
+			dstIP: netip.IPv4Unspecified(),
 			p: &Packet{
 				HardwareType:       1,
 				ProtocolType:       uint16(ethernet.EtherTypeIPv4),
@@ -120,9 +121,9 @@ func TestNewPacket(t *testing.T) {
 				IPLength:           4,
 				Operation:          OperationRequest,
 				SenderHardwareAddr: zeroHW,
-				SenderIP:           net.IPv4zero.To4(),
+				SenderIP:           netip.IPv4Unspecified(),
 				TargetHardwareAddr: zeroHW,
-				TargetIP:           net.IPv4zero.To4(),
+				TargetIP:           netip.IPv4Unspecified(),
 			},
 		},
 	}
@@ -147,8 +148,8 @@ func TestNewPacket(t *testing.T) {
 
 func TestPacketMarshalBinary(t *testing.T) {
 	zeroHW := net.HardwareAddr{0, 0, 0, 0, 0, 0}
-	ip1 := net.IP{192, 168, 1, 10}
-	ip2 := net.IP{192, 168, 1, 1}
+	ip1 := netip.MustParseAddr("192.168.1.10")
+	ip2 := netip.MustParseAddr("192.168.1.1")
 
 	iboip1 := net.HardwareAddr(bytes.Repeat([]byte{0}, 20))
 	iboip2 := net.HardwareAddr(bytes.Repeat([]byte{1}, 20))
@@ -227,8 +228,8 @@ func TestPacketMarshalBinary(t *testing.T) {
 
 func TestPacketUnmarshalBinary(t *testing.T) {
 	zeroHW := net.HardwareAddr{0, 0, 0, 0, 0, 0}
-	ip1 := net.IP{192, 168, 1, 10}
-	ip2 := net.IP{192, 168, 1, 1}
+	ip1 := netip.MustParseAddr("192.168.1.10")
+	ip2 := netip.MustParseAddr("192.168.1.1")
 
 	iboip1 := net.HardwareAddr(bytes.Repeat([]byte{0}, 20))
 	iboip2 := net.HardwareAddr(bytes.Repeat([]byte{1}, 20))
@@ -395,9 +396,9 @@ func Test_parsePacket(t *testing.T) {
 				IPLength:           4,
 				Operation:          OperationReply,
 				SenderHardwareAddr: net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
-				SenderIP:           net.IP{192, 168, 1, 10},
+				SenderIP:           netip.MustParseAddr("192.168.1.10"),
 				TargetHardwareAddr: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
-				TargetIP:           net.IP{192, 168, 1, 1},
+				TargetIP:           netip.MustParseAddr("192.168.1.1"),
 			},
 		},
 	}
@@ -426,9 +427,9 @@ func BenchmarkPacketMarshalBinary(b *testing.B) {
 	p, err := NewPacket(
 		OperationRequest,
 		net.HardwareAddr{0xad, 0xbe, 0xef, 0xde, 0xad, 0xde},
-		net.IP{192, 168, 1, 10},
+		netip.MustParseAddr("192.168.1.10"),
 		net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
-		net.IP{192, 168, 1, 1},
+		netip.MustParseAddr("192.168.1.1"),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -453,9 +454,9 @@ func BenchmarkPacketUnmarshalBinary(b *testing.B) {
 	p, err := NewPacket(
 		OperationRequest,
 		net.HardwareAddr{0xad, 0xbe, 0xef, 0xde, 0xad, 0xde},
-		net.IP{192, 168, 1, 10},
+		netip.MustParseAddr("192.168.1.10"),
 		net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
-		net.IP{192, 168, 1, 1},
+		netip.MustParseAddr("192.168.1.1"),
 	)
 	if err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
This PR removes all use of `net.IP` in favor of the (smaller, faster, immutable) `netip.Addr`. `net` is still needed for the hardware address datastructures, but this will allow the results of the package to be used in maps and will permit other conveniences (like reasonable equality testing).