### PR TITLE
Update go version to 1.18 for net/netip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/arp
 
-go 1.12
+go 1.18
 
 require (
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118


### PR DESCRIPTION
The net/netip library was not added until Go 1.18, so the minimum version should be updated to reflect that.