### PR TITLE
fix: Dev is not configured with an ipv4 address

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,7 +69,7 @@ func New(ifi *net.Interface, p net.PacketConn) (*Client, error) {
 func newClient(ifi *net.Interface, p net.PacketConn, addrs []netip.Addr) (*Client, error) {
 	ip, err := firstIPv4Addr(addrs)
 	if err != nil {
-		return nil, err
+		ip, _ = netip.ParseAddr("0.0.0.0")
 	}
 
 	return &Client{


### PR DESCRIPTION
If the ip address of the device is not configured, the arp client cannot be created and work。In this case, 0.0.0.0 can be used