### PR TITLE
Simplify IPv4 address validation in `NewPacket`

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -93,13 +93,8 @@ func NewPacket(op Operation, srcHW net.HardwareAddr, srcIP netip.Addr, dstHW net
 		return nil, ErrInvalidHardwareAddr
 	}
 
-	// Validate IP addresses to ensure they are IPv4 addresses, and
-	// correct length
-	var invalidIP netip.Addr
-	if !srcIP.IsValid() || !srcIP.Is4() {
-		return nil, ErrInvalidIP
-	}
-	if !dstIP.Is4() || dstIP == invalidIP {
+	// Validate IP addresses to ensure they are IPv4 addresses.
+	if !srcIP.Is4() || !dstIP.Is4() {
 		return nil, ErrInvalidIP
 	}
 


### PR DESCRIPTION
Use `netip.Addr.Is4` to validate both source and destination IP. Also drop the redundant check for an invalid IP. `netip.Addr.Is4` will return false for an invalid `netip.Addr`.